### PR TITLE
feat(auth-svc): sync registration with tax-svc tax profile creation a…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "pkcs1",
  "rand 0.8.5",
  "redis 0.24.0",
+ "reqwest",
  "rsa",
  "serde",
  "serde_json",

--- a/auth-svc/Cargo.toml
+++ b/auth-svc/Cargo.toml
@@ -21,6 +21,7 @@ http = "1"
 tower = "0.5"
 tower-http = { version = "0.5", features = ["trace", "cors"] }
 tower-cookies = "0.10"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 
 # sqlx

--- a/auth-svc/src/auth_core/domain/errors.rs
+++ b/auth-svc/src/auth_core/domain/errors.rs
@@ -13,6 +13,8 @@ pub enum AuthError {
     PasswordUpdateNotAllowed,
     #[error("email already registered")]
     EmailAlreadyRegistered,
+    #[error("registration failed")]
+    RegistrationFailed,
     #[error("email send failed")]
     EmailSendFailed,
     #[error("user not verified")]

--- a/auth-svc/src/auth_core/domain/models.rs
+++ b/auth-svc/src/auth_core/domain/models.rs
@@ -14,6 +14,23 @@ pub enum UserStatus {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RegisterTaxProfile {
+    pub inn: String,
+    pub last_name: String,
+    pub first_name: String,
+    #[serde(default)]
+    pub middle_name: String,
+    pub jurisdiction: String,
+    pub timezone: String,
+    #[serde(default)]
+    pub phone: String,
+    #[serde(default)]
+    pub wallets: Vec<String>,
+    pub tax_residency_status: String,
+    pub taxpayer_type: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct User {
     pub id: Uid,
     pub email: String,

--- a/auth-svc/src/auth_core/domain/ports.rs
+++ b/auth-svc/src/auth_core/domain/ports.rs
@@ -10,6 +10,7 @@ pub trait UserRepo: Send + Sync {
     async fn find_by_email(&self, email_lower: &str) -> Result<Option<UserWithHash>>;
     async fn activate(&self, user_id: Uid) -> Result<bool>;
     async fn update_password(&self, user_id: Uid, password_hash: &str) -> Result<()>;
+    async fn delete_pending_user(&self, user_id: Uid) -> Result<bool>;
 }
 
 #[async_trait]
@@ -22,6 +23,11 @@ pub trait EmailVerificationRepo: Send + Sync {
 #[async_trait]
 pub trait Mailer: Send + Sync {
     async fn send_verification(&self, to: &str, verify_link: &str) -> Result<()>;
+}
+
+#[async_trait]
+pub trait TaxProfileClient: Send + Sync {
+    async fn upsert_tax_profile(&self, user_id: Uid, profile: &RegisterTaxProfile) -> Result<()>;
 }
 
 #[async_trait]

--- a/auth-svc/src/auth_core/usecase/mod.rs
+++ b/auth-svc/src/auth_core/usecase/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 
 #[async_trait]
 pub trait AuthService: Send + Sync {
-    async fn register(&self, email: &str, pwd: &str) -> Result<()>;
+    async fn register(&self, email: &str, pwd: &str, tax_profile: &RegisterTaxProfile) -> Result<()>;
     async fn verify_email(&self, token: &str) -> Result<()>;
     async fn refresh(&self, refresh_token: &str) -> Result<Tokens>;
     async fn logout(&self, access: &str) -> Result<()>;
@@ -36,6 +36,7 @@ pub struct AuthUseCases<
     C: RevocationCache,
     E: EmailVerificationRepo,
     M: Mailer,
+    P: TaxProfileClient,
 > {
     pub users: U,
     pub sessions: S,
@@ -46,13 +47,14 @@ pub struct AuthUseCases<
     pub cache: C,
     pub email_verification: E,
     pub mailer: M,
+    pub tax_profiles: P,
     pub verify_config: VerifyEmailConfig,
     pub access_ttl: i64,
     pub refresh_ttl: i64,
     pub dummy_password_hash: String,
 }
 
-impl<U, S, R, H, T, F, C, E, M> AuthUseCases<U, S, R, H, T, F, C, E, M>
+impl<U, S, R, H, T, F, C, E, M, P> AuthUseCases<U, S, R, H, T, F, C, E, M, P>
 where
     U: UserRepo,
     S: SessionRepo,
@@ -63,6 +65,7 @@ where
     C: RevocationCache,
     E: EmailVerificationRepo,
     M: Mailer,
+    P: TaxProfileClient,
 {
     pub async fn handle_reuse(&self, rec: &RefreshToken) -> Result<()> {
         self.refresh.revoke_all_for_session(rec.session_id).await?;
@@ -93,7 +96,7 @@ where
 }
 
 #[async_trait]
-impl<U, S, R, H, T, F, C, E, M> AuthService for AuthUseCases<U, S, R, H, T, F, C, E, M>
+impl<U, S, R, H, T, F, C, E, M, P> AuthService for AuthUseCases<U, S, R, H, T, F, C, E, M, P>
 where
     U: UserRepo,
     S: SessionRepo,
@@ -104,13 +107,37 @@ where
     C: RevocationCache,
     E: EmailVerificationRepo,
     M: Mailer,
+    P: TaxProfileClient,
 {
-    async fn register(&self, email: &str, password: &str) -> Result<()> {
+    async fn register(&self, email: &str, password: &str, tax_profile: &RegisterTaxProfile) -> Result<()> {
         let email_norm = normalize_email(email)?;
         validate_password_strength(password, &email_norm)?;
 
         let pwd_hash = self.hasher.hash(password)?;
         if let Some(new_user_id) = self.users.create_user(&email_norm, &pwd_hash).await? {
+            if let Err(err) = self.tax_profiles.upsert_tax_profile(new_user_id, tax_profile).await {
+                match self.users.delete_pending_user(new_user_id).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        error!(
+                            user_id = %new_user_id,
+                            "tax profile sync failed and compensating delete affected 0 rows"
+                        );
+                        return Err(AuthError::Internal);
+                    }
+                    Err(cleanup_err) => {
+                        error!(
+                            user_id = %new_user_id,
+                            ?cleanup_err,
+                            "tax profile sync failed and compensating delete failed"
+                        );
+                        return Err(cleanup_err);
+                    }
+                }
+
+                return Err(err);
+            }
+
             let (token, hash_bytes, exp) = self.new_verification_token();
             self.email_verification.create_token(new_user_id, hash_bytes, &email_norm, exp).await?;
 
@@ -130,6 +157,8 @@ where
             UserStatus::Active | UserStatus::Blocked => Err(AuthError::EmailAlreadyRegistered),
             UserStatus::Pending => {
                 self.users.update_password(existing.id, &pwd_hash).await?;
+                self.tax_profiles.upsert_tax_profile(existing.id, tax_profile).await?;
+
                 let (token, hash_bytes, exp) = self.new_verification_token();
                 if let Err(err) = self.email_verification.revoke_all_for_user(existing.id).await {
                     tracing::error!(

--- a/auth-svc/src/config.rs
+++ b/auth-svc/src/config.rs
@@ -65,6 +65,12 @@ pub struct VerifyEmailConfig {
 }
 
 #[derive(Clone, Debug)]
+pub struct TaxSvcConfig {
+    pub base_url: String,
+    pub timeout_secs: u64,
+}
+
+#[derive(Clone, Debug)]
 pub struct AppConfig {
     pub server: ServerConfig,
     pub db: DbConfig,
@@ -74,6 +80,7 @@ pub struct AppConfig {
     pub mailer: SmtpConfig,
     pub password: PasswordConfig,
     pub verify: VerifyEmailConfig,
+    pub tax_svc: TaxSvcConfig,
     pub dummy_password_hash: String,
 }
 
@@ -136,6 +143,11 @@ impl AppConfig {
             token_ttl_secs: get("EMAIL_VERIFY_TTL_SECS", "86400").parse().unwrap_or(86_400),
         };
 
+        let tax_svc = TaxSvcConfig {
+            base_url: get("TAX_SVC_URL", "http://127.0.0.1:8097"),
+            timeout_secs: get("TAX_SVC_TIMEOUT_SECS", "5").parse().unwrap_or(5),
+        };
+
         let dummy_password_hash = get(
             "DUMMY_PASSWORD_HASH",
             "$argon2id$v=19$m=65536,t=3,p=1$R0VORVJBVEVEX1NBTFQ$8v0QWnN8S2sRzR2VdX1lA4O3p2y1W8Q4G8g7w8r2s1U",
@@ -150,6 +162,7 @@ impl AppConfig {
             mailer,
             password,
             verify,
+            tax_svc,
             dummy_password_hash,
         })
     }

--- a/auth-svc/src/error.rs
+++ b/auth-svc/src/error.rs
@@ -21,6 +21,7 @@ fn map_auth_err(err: AuthError) -> (StatusCode, ErrBody) {
         UserNotVerified | UserBlocked => StatusCode::FORBIDDEN,
         EmailInvalid | PasswordWeak(_) => StatusCode::UNPROCESSABLE_ENTITY,
         InvalidCredentials | TokenExpired | TokenInvalid | TokenReuse => StatusCode::UNAUTHORIZED,
+        RegistrationFailed => StatusCode::BAD_GATEWAY,
         EmailSendFailed => StatusCode::SERVICE_UNAVAILABLE,
         Storage(_) | Internal => StatusCode::INTERNAL_SERVER_ERROR,
     };

--- a/auth-svc/src/infra/db/repos/user_repo.rs
+++ b/auth-svc/src/infra/db/repos/user_repo.rs
@@ -99,4 +99,20 @@ impl UserRepo for PgUserRepo {
             None => Err(AuthError::PasswordUpdateNotAllowed),
         }
     }
+
+    async fn delete_pending_user(&self, user_id: Uid) -> Result<bool, AuthError> {
+        let res = sqlx::query(
+            r#"
+            DELETE FROM users
+            WHERE id = $1
+              AND status = 'Pending'::user_status
+            "#,
+        )
+        .bind(user_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AuthError::Storage(format!("users.delete_pending_user: {e}")))?;
+
+        Ok(res.rows_affected() == 1)
+    }
 }

--- a/auth-svc/src/infra/mod.rs
+++ b/auth-svc/src/infra/mod.rs
@@ -1,9 +1,11 @@
 pub mod crypto;
 pub mod db;
 pub mod mailer;
+pub mod tax_profile_client;
 // pub mod aws_mailer;
 
 pub use crypto::*;
 pub use db::*;
 pub use mailer::*;
+pub use tax_profile_client::*;
 // pub use aws_mailer::*;

--- a/auth-svc/src/infra/tax_profile_client.rs
+++ b/auth-svc/src/infra/tax_profile_client.rs
@@ -1,0 +1,73 @@
+use std::time::Duration;
+
+use axum::async_trait;
+use tracing::warn;
+
+use crate::{
+    auth_core::{
+        errors::AuthError,
+        models::{RegisterTaxProfile, Uid},
+        ports::TaxProfileClient,
+    },
+    config::TaxSvcConfig,
+};
+
+pub struct TaxSvcClient {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl TaxSvcClient {
+    pub fn new(cfg: TaxSvcConfig) -> Result<Self, AuthError> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(cfg.timeout_secs))
+            .build()
+            .map_err(|e| AuthError::Storage(format!("tax_svc.client_build: {e}")))?;
+
+        Ok(Self {
+            client,
+            base_url: cfg.base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    fn upsert_profile_url(&self, user_id: Uid) -> String {
+        format!("{}/v1/tenants/{user_id}/tax/profile", self.base_url)
+    }
+
+    fn truncate_for_log(input: &str, max_chars: usize) -> String {
+        let mut out: String = input.chars().take(max_chars).collect();
+        if input.chars().count() > max_chars {
+            out.push_str("...");
+        }
+        out
+    }
+}
+
+#[async_trait]
+impl TaxProfileClient for TaxSvcClient {
+    async fn upsert_tax_profile(&self, user_id: Uid, profile: &RegisterTaxProfile) -> Result<(), AuthError> {
+        let url = self.upsert_profile_url(user_id);
+
+        let response = self.client.put(&url).json(profile).send().await.map_err(|err| {
+            warn!(user_id=%user_id, ?err, "tax-svc upsert request failed");
+            AuthError::RegistrationFailed
+        })?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        let body = Self::truncate_for_log(&body, 512);
+
+        warn!(
+            user_id = %user_id,
+            status = %status.as_u16(),
+            body = %body,
+            "tax-svc upsert returned non-success status"
+        );
+
+        Err(AuthError::RegistrationFailed)
+    }
+}

--- a/auth-svc/src/routes/dto.rs
+++ b/auth-svc/src/routes/dto.rs
@@ -1,10 +1,13 @@
 use serde::Deserialize;
 
+use crate::auth_core::models::RegisterTaxProfile;
+
 /// ----- DTOs -----
 #[derive(Deserialize)]
 pub struct RegisterReq {
     pub email: String,
     pub password: String,
+    pub tax_profile: RegisterTaxProfile,
 }
 
 #[derive(Deserialize)]

--- a/auth-svc/src/routes/handlers.rs
+++ b/auth-svc/src/routes/handlers.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub async fn register_handler(State(auth): State<Auth>, Json(reg): Json<RegisterReq>) -> Result<Json<Value>> {
-    auth.register(&reg.email, &reg.password).await?;
+    auth.register(&reg.email, &reg.password, &reg.tax_profile).await?;
     Ok(Json(json!({ "ok": true })))
 }
 

--- a/auth-svc/src/routes/mod.rs
+++ b/auth-svc/src/routes/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     config::AppConfig,
     db::make_pool,
     infra::{
-        PepperSet, SmtpMailer,
+        PepperSet, SmtpMailer, TaxSvcClient,
         jwt_issuer_rs256::JwtIssuerRs,
         password_hasher_argon2::{Argon2Hasher, KdfParams},
         redis::RedisCache,
@@ -49,6 +49,7 @@ pub async fn build_state(cfg: &AppConfig) -> Result<AppState> {
     let email_verification = PgEmailVerificationRepo::new(pg.clone());
     let refresh_factory = RefreshFactory::new(cfg.refresh.clone());
     let mailer = SmtpMailer::new(cfg.mailer.clone())?;
+    let tax_profiles = TaxSvcClient::new(cfg.tax_svc.clone())?;
 
     let decoded_pepper: Vec<u8> = Base64Url::decode_vec(cfg.password.pepper.as_str()).unwrap();
     let peppers = PepperSet::new_current_only(decoded_pepper);
@@ -73,6 +74,7 @@ pub async fn build_state(cfg: &AppConfig) -> Result<AppState> {
         cache,
         email_verification,
         verify_config: cfg.verify.clone(),
+        tax_profiles,
         access_ttl: cfg.jwt.access_ttl_secs,
         refresh_ttl: cfg.refresh.ttl_secs,
         dummy_password_hash: cfg.dummy_password_hash.clone(),


### PR DESCRIPTION
## What
This PR updates `auth-svc` registration flow to synchronously create a related `TaxProfile` in `tax-svc` and apply compensating rollback on failure.

## Changes
- Extended `POST /auth/register` payload with `tax_profile`.
- Added synchronous REST call from `auth-svc` to `tax-svc`:
  - `PUT /v1/tenants/{user_id}/tax/profile`
- Updated registration orchestration in `auth-svc`:
  - create user in `Pending`
  - call `tax-svc` to create/upsert `TaxProfile`
  - if `tax-svc` fails (error/timeout/non-2xx), delete newly created pending user in `auth-svc`
- Added compensation method in user repository to delete only pending user by id.
- Added `tax-svc` client/config wiring in `auth-svc` (`TAX_SVC_URL`, `TAX_SVC_TIMEOUT_SECS`).
- Added registration failure mapping for downstream sync failure.

## Why
Registration must be considered successful only when both records exist:
1. user in `auth-svc`
2. `TaxProfile` in `tax-svc`

Without compensation, system can end up in inconsistent state (user exists in `auth-svc` without profile in `tax-svc`).

## Result
- `auth-svc` now acts as coordinator for a 2-step synchronous registration flow.
- No inconsistent state after failed `tax-svc` profile creation in new-user path (user creation is rolled back).
- Client still uses a single registration endpoint in `auth-svc`.