### PR TITLE
feat(ledger-svc): add endpoint to list supported exchanges

### DIFF
--- a/ledger-svc/src/routes/handlers.rs
+++ b/ledger-svc/src/routes/handlers.rs
@@ -79,6 +79,11 @@ pub async fn health_handler(State(_state): State<AppState>) -> Result<Json<Value
     Ok(Json(json!({ "status": "im alive" })))
 }
 
+pub async fn list_supported_exchanges_handler(State(state): State<AppState>) -> Result<Json<Value>> {
+    let exchanges = state.registry.list_supported();
+    Ok(Json(json!({ "exchanges": exchanges })))
+}
+
 #[derive(Deserialize)]
 pub struct ImportTransactionsPath {
     pub tenant_id: String,

--- a/ledger-svc/src/routes/mod.rs
+++ b/ledger-svc/src/routes/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         make_pool,
         pq::{import_repo::PgImportRepository, tx_repo::PgTransactionQueryRepository, uow::PgImportUnitOfWorkFactory},
     },
-    routes::handlers::{health_handler, list_import_transactions_handler, mexc_csv_handler},
+    routes::handlers::{health_handler, list_import_transactions_handler, list_supported_exchanges_handler, mexc_csv_handler},
 };
 
 pub struct ExchangeRegistry {
@@ -41,6 +41,12 @@ impl ExchangeRegistry {
 
     pub fn insert(&mut self, id: ExchangeId, svc: Box<dyn ExchangeService>) {
         self.exchanges.insert(id, svc);
+    }
+
+    pub fn list_supported(&self) -> Vec<String> {
+        let mut out: Vec<String> = self.exchanges.keys().map(ToString::to_string).collect();
+        out.sort_unstable();
+        out
     }
 }
 
@@ -87,6 +93,7 @@ pub async fn build_state(cfg: &AppConfig) -> Result<AppState> {
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health_handler))
+        .route("/v1/exchanges/supported", get(list_supported_exchanges_handler))
         .route("/mexc/csv", post(mexc_csv_handler))
         .route("/v1/tenants/:tenant_id/imports/:import_id/transactions", get(list_import_transactions_handler))
         .with_state(state)


### PR DESCRIPTION
## Summary
- Added a new read-only endpoint in `ledger-svc`: `GET /v1/exchanges/supported`.
- The endpoint returns currently enabled exchanges from the runtime registry (not hardcoded).
- Response is deterministic (sorted) and UI-friendly: `{ "exchanges": ["mexc", "okx", ...] }`.

Closed #3 